### PR TITLE
Use bucket uploads for test builds

### DIFF
--- a/.github/workflows/push-workflow.yml
+++ b/.github/workflows/push-workflow.yml
@@ -4,7 +4,7 @@ name: Push Workflow
 env:
   REGION: us-east-1
   DIST_OUTPUT_BUCKET: sb-poc-solutions-features
-  REGIONS_TO_DEPLOY: "us-west-2 us-east-1"
+  REGIONS_TO_DEPLOY: "us-west-2 us-east-1 eu-west-1"
   RELEASE_OUTPUT_BUCKET: sb-poc-solutions
   VERSION: ${{ secrets.VERSION }}
   RELEASE_BRANCH: main 

--- a/.github/workflows/push-workflow.yml
+++ b/.github/workflows/push-workflow.yml
@@ -254,24 +254,24 @@ jobs:
             cat error.txt
             exit 1
           fi
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@master
-      #   with:
-      #     role-to-assume: ${{ secrets.VWR_ROLE_ARN }}
-      #     aws-region: ${{ env.REGION }}
-      #     role-duration-seconds: 900
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          role-to-assume: ${{ secrets.VWR_ROLE_ARN }}
+          aws-region: ${{ env.REGION }}
+          role-duration-seconds: 900
       - name: Restore deployment directory from cache
         uses: actions/cache@v2
         id: cache-deployment
         with:
           path: deployment/
           key: ${{ github.sha }}
-      # - name: Upload to S3
-      #   # deploy to our test bucket if not doing a release
-      #   if: ${{github.ref_name != env.RELEASE_BRANCH}}
-      #   run: |
-      #     cd deployment
-      #     ./deploy.sh -b $DIST_OUTPUT_BUCKET -s ${{ github.event.repository.name }} -v $VERSION -r "$REGIONS_TO_DEPLOY" -a none -t dev
+      - name: Upload to S3
+        # deploy to our test bucket if not doing a release
+        if: ${{github.ref_name != env.RELEASE_BRANCH}}
+        run: |
+          cd deployment
+          ./deploy.sh -b $DIST_OUTPUT_BUCKET -s ${{ github.event.repository.name }} -v $VERSION -r "$REGIONS_TO_DEPLOY"
       - name: Zip up regional and global assets
         run: |
           cd deployment


### PR DESCRIPTION
*Description of changes:*
Change permissions on test system to allow bucket operations on POC buckets
Disable notification workflow in Actions console
Uncomment credentials and deploy.sh jobs in push workflow
Update CLI parameters used for deploy.sh

*Test builds from push workflow are uploaded to these buckets:*
sb-poc-solutions-features-us-east-1
sb-poc-solutions-features-us-west-2
sb-poc-solutions-features-eu-west-1

We can add more regional buckets as needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
