### PR TITLE
Don't set ACL when uploading test builds

### DIFF
--- a/.github/workflows/push-workflow.yml
+++ b/.github/workflows/push-workflow.yml
@@ -271,7 +271,7 @@ jobs:
         if: ${{github.ref_name != env.RELEASE_BRANCH}}
         run: |
           cd deployment
-          ./deploy.sh -b $DIST_OUTPUT_BUCKET -s ${{ github.event.repository.name }} -v $VERSION -r "$REGIONS_TO_DEPLOY"
+          ./deploy.sh -b $DIST_OUTPUT_BUCKET -s ${{ github.event.repository.name }} -v $VERSION -r "$REGIONS_TO_DEPLOY" -a none
       - name: Zip up regional and global assets
         run: |
           cd deployment


### PR DESCRIPTION
*Description of changes:*
Setting the ACL for our test buckets does not work due to BPA activated.
Changed the options for the deploy.sh script to `-a none` to prevent setting an ACL on the objects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
