### PR TITLE
Add sonar-project.properties for code scanning

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,74 @@
+
+# Note: Currently testing and supported with code coverage sonarqube
+# collection for python lambda (python pytest, python unittest) and javascript jest
+# and CDK TypeScript
+
+# Uncomment to enable debugging by default
+#sonar.verbose=true
+#sonar.log.level=DEBUG
+
+# Disable if needed
+#sonar.scm.disabled=true
+
+#
+# Refer to https://docs.sonarqube.org/latest/project-administration/narrowing-the-focus/
+# for details on sources and exclusions. Note also .gitignore
+#
+
+sonar.sources=source
+    
+sonar.exclusions= \
+    **/package/**, \
+    **/.aws-sam/**, \
+    **/test/**, \
+    source/tools/**
+
+
+# sonar.tests=source/test
+
+sonar.sourceEncoding=UTF-8
+
+## Python Specific Properties*
+# coverage
+# https://docs.sonarqube.org/pages/viewpage.action?pageId=4784149
+#   Comma-separated list of ant pattern describing paths to coverage reports, relative to projects
+#   root. Leave unset to use the default ("coverage-reports/*coverage-*.xml").
+
+# sonar.python.coverage.reportPaths= \
+#     source/msam/coverage.xml, \
+#     source/events/coverage.xml
+
+
+# Sensor SonarJS Coverage [javascript] was not allowing globbing
+# for sonar.javascript.lcov.reportPaths such as this
+#    source/test/coverage-reports/jest/*/lcov.info
+# so we have to provide an explicit list of reportPaths
+
+# sonar.javascript.lcov.reportPaths= \
+#     source/html/lcov.info
+
+
+#     source/test/coverage-reports/jest/create-partition/lcov.info, \
+#     source/test/coverage-reports/jest/firehose-text-proxy/lcov.info, \
+#     source/test/coverage-reports/jest/ingestion-consumer/lcov.info, \
+#     source/test/coverage-reports/jest/ingestion-producer/lcov.info, \
+#     source/test/coverage-reports/jest/ingestion-youtube/lcov.info, \
+#     source/test/coverage-reports/jest/integration/lcov.info, \
+#     source/test/coverage-reports/jest/layers/aws-nodesdk-custom-config/lcov.info, \
+#     source/test/coverage-reports/jest/storage-firehose-processor/lcov.info, \
+#     source/test/coverage-reports/jest/wf-analyze-text/lcov.info, \
+#     source/test/coverage-reports/jest/wf-check-topic-model/lcov.info, \
+#     source/test/coverage-reports/jest/wf-detect-language/lcov.info, \
+#     source/test/coverage-reports/jest/wf-detect-moderation-labels/lcov.info, \
+#     source/test/coverage-reports/jest/wf-extract-text-in-image/lcov.info, \
+#     source/test/coverage-reports/jest/wf-publish-text-inference/lcov.info, \
+#     source/test/coverage-reports/jest/wf-submit-topic-model/lcov.info, \
+#     source/test/coverage-reports/jest/wf-translate-text/lcov.info, \
+
+# Project Specific ignores with rational
+# sonar.issue.ignore.multicriteria=ts1
+
+# TODO: Temporary ignore for typescript:S1848. Review and update code as needed. Only ignore this for typescript file which are in CDK since there are many common cases of new <SomeClass>(this, ...) without using the created object.
+#typescript:S1848 Objects should not be created to be dropped immediately without being used
+# sonar.issue.ignore.multicriteria.ts1.ruleKey=typescript:S1848
+# sonar.issue.ignore.multicriteria.ts1.resourceKey=**/*.ts


### PR DESCRIPTION
*Description of changes:*
Add SonarQube properties file for checks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
