### PR TITLE
Hotfix for high number of Expired and Active.

### DIFF
--- a/source/control-panel/src/components/ActiveTokens.vue
+++ b/source/control-panel/src/components/ActiveTokens.vue
@@ -20,7 +20,10 @@ is an object containing the endpoints and credentials for the API.
       <span v-if="updateSuccess" class="badge bg-success mx-2">connected</span>
       <span v-if="updateError" class="badge bg-danger mx-2">check configuration</span>
     </p>
-    <p class="h2 m-2">{{ activeTokens }}</p>
+    <div class="d-flex flex-row justify-content-between">
+      <p class="h2 m-2">{{ activeTokens }}</p>
+      <button type="button" class="btn btn-sm btn-secondary rounded m-1 p-3" v-on:click="updateActiveTokenCount">Update</button>
+    </div>
   </div>
 </template>
 
@@ -29,7 +32,7 @@ is an object containing the endpoints and credentials for the API.
 import { mixin as VueTimers } from "vue-timers";
 import { AwsClient } from 'aws4fetch';
 // update interval for the API call
-const UPDATE_INTERVAL_MS = 5000;
+const UPDATE_INTERVAL_MS = 60000;
 export default {
   name: "ActiveTokens",
   mixins: [VueTimers],

--- a/source/control-panel/src/components/ExpiredTokens.vue
+++ b/source/control-panel/src/components/ExpiredTokens.vue
@@ -15,7 +15,10 @@ SPDX-License-Identifier: Apache-2.0
       <span v-if="updateError" class="badge bg-danger mx-2">check configuration</span>
     </p>
     <!-- show the last expired tokens count retrieved -->
-    <p class="h2 m-2">{{ expiredTokens }}</p>
+    <div class="d-flex flex-row justify-content-between">
+      <p class="h2 m-2">{{ expiredTokens }}</p>
+      <button type="button" class="btn btn-sm btn-secondary rounded m-1 p-3" v-on:click="updateWaitingRoomSize">Update</button>
+    </div>
   </div>
 </template>
 
@@ -23,7 +26,7 @@ SPDX-License-Identifier: Apache-2.0
 import { mixin as VueTimers } from "vue-timers";
 import { AwsClient } from 'aws4fetch';
 // longer update interval since this call is more expensive
-const UPDATE_INTERVAL_MS = 30000;
+const UPDATE_INTERVAL_MS = 60000;
 export default {
   name: "ExpiredTokens",
   mixins: [VueTimers],


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

This is a hotfix because if it is long running and the number of Expired Tokens and Active Tokens is very high, the Lambda function can time out for more than 30 seconds when multiple people open the control panel.

<img width="741" alt="スクリーンショット 2022-12-25 0 07 54" src="https://user-images.githubusercontent.com/24556516/209442077-8960cdc3-c932-4afd-99f2-ab6be4233156.png">

