### PR TITLE
Fixed a bug that did not return the correct array

### DIFF
--- a/source/core-api/lambda_functions/get_list_expired_tokens.py
+++ b/source/core-api/lambda_functions/get_list_expired_tokens.py
@@ -50,7 +50,7 @@ def lambda_handler(event, _):
                     ProjectionExpression="request_id",
                     KeyConditionExpression=Key('event_id').eq(EVENT_ID) & Key('expires').lt(current_time),
                     ExclusiveStartKey=response["LastEvaluatedKey"])
-                items.append([item['request_id'] for item in response['Items']])
+                items.extend([item['request_id'] for item in response['Items']])
             response = {
                 "statusCode": 200,
                 "headers": headers,


### PR DESCRIPTION
Fixed a bug that causes a secondary array when the number of elements is 4504 or more.


For example.
"body": "[\"00001\", \"00002\", \"00003\", .......\"04503\",[\"04504\", \"04505\",..... ]]


*Issue #, if available:*

*Description of changes:*

Changed Array append method from "append" to "extend"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
